### PR TITLE
Fix requirements.txt voor Python 3.13 compatibiliteit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,31 +1,31 @@
 # Python 3.8 of hoger vereist, getest t/m Python 3.13
-# Voor Python 3.13 gebruikers: installeer eerst setuptools met: pip install --upgrade setuptools>=68.0.0
+# Voor Python 3.13 gebruikers: pip install --upgrade pip setuptools>=69.0.0 wheel
 
 # Data processing & analysis
-pandas==1.5.3
-numpy==1.24.3
-scikit-learn==1.2.2
+pandas>=2.0.0
+numpy>=1.26.0
+scikit-learn>=1.3.0
 
 # Machine learning
-xgboost==1.7.6
-lightgbm==3.3.5
-shap==0.41.0  # Voor model interpretability
+xgboost>=1.7.6
+lightgbm>=4.0.0
+shap>=0.42.0  # Voor model interpretability
 
 # Visualization
-matplotlib==3.7.1
-seaborn==0.12.2
-plotly==5.14.1
+matplotlib>=3.8.0
+seaborn>=0.13.0
+plotly>=5.18.0
 
 # Web interface
-dash==2.9.3
-dash-bootstrap-components==1.4.1
-flask==2.3.2
+dash>=2.13.0
+dash-bootstrap-components>=1.5.0
+flask>=2.3.3
 
 # Utilities
-python-dotenv==1.0.0
-joblib==1.2.0  # Voor model serialization
-tqdm==4.65.0   # Voor progress bars
+python-dotenv>=1.0.0
+joblib>=1.3.0  # Voor model serialization
+tqdm>=4.66.0   # Voor progress bars
 
 # Testing
-pytest==7.3.1
-pytest-cov==4.1.0
+pytest>=7.4.0
+pytest-cov>=4.1.0


### PR DESCRIPTION
Deze PR lost issue #20 op door de requirements.txt aan te passen voor Python 3.13 compatibiliteit.

### Wijzigingen:
- Bijgewerkt naar nieuwere versies van alle pakket-dependencies die compatibel zijn met Python 3.13
- Veranderd van specifieke versienummers naar minimale versienummers (>= format) voor betere flexibiliteit
- Bijgewerkte installatierichtlijn voor Python 3.13 gebruikers om eerst pip, setuptools en wheel te upgraden
- In het bijzonder opgelost: setuptools >= 69.0.0 is nodig voor Python 3.13 compatibiliteit

De fout werd veroorzaakt door het ontbreken van `pkgutil.ImpImporter` in Python 3.13, wat is verwijderd in nieuwere Python versies. Door de nieuwere versies van de dependencies te gebruiken, wordt dit probleem opgelost.

### Testen:
Deze wijzigingen zijn getest met Python 3.13.1.

Fixes #20