### PR TITLE
Fix Module Import Error in app.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cd KaggleTitanic
 2. Maak een virtuele omgeving aan:
 ```
 python -m venv venv
-source venv/bin/activate  # Op Windows: venv\Scripts\activate
+source venv/bin/activate  # Op Windows: venv\\Scripts\\activate
 ```
 
 3. Installeer de vereiste packages:
@@ -55,10 +55,16 @@ pip install -r requirements.txt
 
 ### Web Interface
 
-Start de web interface:
+Start de web interface met het nieuwe run.py script:
 
 ```
-python src/web_interface/app.py
+python run.py
+```
+
+Of als alternatief kun je het volgende gebruiken (indien je Python path correct is geconfigureerd):
+
+```
+python -m src.web_interface.app
 ```
 
 Open vervolgens je browser en ga naar `http://localhost:5000`.

--- a/run.py
+++ b/run.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Titanic Survival Predictor - Main Execution Script
+
+This script acts as the application entry point. It handles path configuration to ensure
+that the 'src' package is properly recognized and imported, regardless of whether the app
+is run from the root directory or from within the src directory.
+
+Usage:
+    python run.py
+
+This will start the Flask web application on http://localhost:5000
+"""
+
+import os
+import sys
+
+# Ensure that the src package can be imported regardless of where the script is run from
+PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, PROJECT_ROOT)
+
+# Now we can safely import from the src package
+from src.web_interface.app import app
+
+if __name__ == '__main__':
+    print("Starting Titanic Survival Predictor Web Application...")
+    print("Open your browser and navigate to http://localhost:5000")
+    app.run(debug=True)


### PR DESCRIPTION
## Beschrijving
Deze PR lost het probleem op waarbij het uitvoeren van `python src/web_interface/app.py` een `ModuleNotFoundError: No module named 'src'` fout veroorzaakt zoals beschreven in issue #23.

## Wijzigingen
- Een nieuwe `run.py` bestand toegevoegd in de hoofdmap dat de Python path correct instelt en de app start
- De README bijgewerkt met instructies voor het gebruik van het nieuwe run.py script
- Een alternatieve methode toegevoegd om de app te starten met `python -m src.web_interface.app`

## Testen
De app kan nu correct worden gestart met de volgende methoden:
1. `python run.py` vanuit de hoofdmap van het project
2. `python -m src.web_interface.app` vanuit de hoofdmap (als alternatief)

## Opmerkingen
Dit is een veelvoorkomend probleem met Python modules en pakketstructuren. De fix zorgt ervoor dat de projectmap wordt toegevoegd aan de Python path, zodat de `src` module correct kan worden geïmporteerd.

Fixes #23